### PR TITLE
Lower case extensions in parsed.path.lower() in sampleConfig.py

### DIFF
--- a/SampleConfig.py
+++ b/SampleConfig.py
@@ -34,10 +34,10 @@ class SampleConfig(Config):
         try:
             return ".ics.uci.edu" in parsed.hostname \
                 and not re.match(".*\.(css|js|bmp|gif|jpe?g|ico" + "|png|tiff?|mid|mp2|mp3|mp4"\
-			    + "|wav|avi|mov|mpeg|ram|m4v|mkv|ogg|ogv|pdf" \
-			    + "|ps|eps|tex|ppt|pptx|doc|docx|xls|xlsx|names|data|dat|exe|bz2|tar|msi|bin|7z|psd|dmg|iso|epub|dll|cnf|tgz|sha1" \
-			    + "|thmx|mso|arff|rtf|jar|csv"\
-			    + "|rm|smil|wmv|swf|wma|zip|rar|gz)$", parsed.path)
+                + "|wav|avi|mov|mpeg|ram|m4v|mkv|ogg|ogv|pdf" \
+                + "|ps|eps|tex|ppt|pptx|doc|docx|xls|xlsx|names|data|dat|exe|bz2|tar|msi|bin|7z|psd|dmg|iso|epub|dll|cnf|tgz|sha1" \
+                + "|thmx|mso|arff|rtf|jar|csv"\
+                + "|rm|smil|wmv|swf|wma|zip|rar|gz)$", parsed.path.lower())
 
         except TypeError:
             print ("TypeError for ", parsed)


### PR DESCRIPTION
the regex was not picking up uppercase extensions. example:
http://www.example.com/image.JPG

you can take a look at the screen shot below
http://imgur.com/BLghdC5
