### PR TITLE
Fixing the validation for UserAgentString

### DIFF
--- a/Crawler4py/Config.py
+++ b/Crawler4py/Config.py
@@ -67,7 +67,7 @@ class Config:
     def ValidateConfig(self):
         '''Validates the config to see if everything is in order. No need to extend this'''
         try:
-            assert (self.UserAgentString != "" or self.UserAgentString != "Set This Value!")
+            assert (self.UserAgentString != "" and self.UserAgentString != "Set This Value!")
         except AssertionError:
             print ("Set value of UserAgentString")
             sys.exit(1)


### PR DESCRIPTION
Currently even without setting the UserAgentString variable the code is proceeding with the crawling. 
Because of the "or" condition since the default value "Set This Value!" != "" results in true assertion. Changing it to "and".
