### PR TITLE
feature: ability to configure custom persistence object

### DIFF
--- a/Crawler4py/Config.py
+++ b/Crawler4py/Config.py
@@ -36,8 +36,11 @@ class Config:
         #PolitenessDelay that the crawler is forced to adhere to. http://en.wikipedia.org/wiki/Web_crawler#Politeness_policy
         self.PolitenessDelay = 300
 
-        #The Persistent File to store current state of crawler for resuming (if Resumable is True)
+        #The Persistent File to store current state of crawler for resuming (if Resumable is True and PersistenceObject is None)
         self.PersistentFile = "Persistent.shelve"
+
+        # Users may want to use their own persistence object.
+        self.PersistenceObject = None
 
         #Total (Approximate) documents to fetch before stopping
         self.NoOfDocToFetch = -1

--- a/Crawler4py/UrlManager.py
+++ b/Crawler4py/UrlManager.py
@@ -36,22 +36,28 @@ class UrlManager:
     def __Init(self):
         self.ShelveObj = None
         if self.config.Resumable:
-            if (os.access(self.config.PersistentFile, os.F_OK)):
-                self.ShelveObj = shelve.open(self.config.PersistentFile)
-                keys = self.ShelveObj.keys()
-                if len(keys) > 0:
-                    for key in keys:
-                        if not self.ShelveObj[key][0]:
-                            self.Frontier.add((key.decode("utf-8"), self.ShelveObj[key][1]))
-                    return
+            if self.config.PersistenceObject != None:
+                self.ShelveObj = self.config.PersistenceObject
+                self.__Resume()
+            else:
+                if (os.access(self.config.PersistentFile, os.F_OK)):
+                    self.ShelveObj = shelve.open(self.config.PersistentFile)
+                    self.__Resume()
 
-            self.ShelveObj = shelve.open(self.config.PersistentFile)
+                self.ShelveObj = shelve.open(self.config.PersistentFile)
 
         for url in self.config.GetSeeds():
             self.AddToFrontier(url, 0)
         
         return
 
+    def __Resume(self):
+        keys = self.ShelveObj.keys()
+        if len(keys) > 0:
+            for key in keys:
+                if not self.ShelveObj[key][0]:
+                    self.Frontier.add((key.decode("utf-8"), self.ShelveObj[key][1]))
+            return
 
     def __CleanUrl(self, url):
         parsedset = urlparse.urlparse(url)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ MaxRetryDownloadOnFail : Number of times to retry fetching a url if it fails
 
 PolitenessDelay : PolitenessDelay that the crawler is forced to adhere to. http://en.wikipedia.org/wiki/Web_crawler#Politeness_policy
 
-PersistentFile : The Persistent File to store current state of crawler for resuming (if Resumable is True)
+PersistentFile : The Persistent File to store current state of crawler for resuming (if Resumable is True and PersistenceObject is None)
+
+PersistenceObject : Defaults to None, can be set to some object you provide (e.g. to use a network resource such as Redis instead of local disk) [postgres example](https://gist.github.com/kfatehi/90e27415e15eaeb19f7b)
 
 NoOfDocToFetch : Total (Approximate) documents to fetch before stopping
 


### PR DESCRIPTION
I keep running out of disk space on openlab (because I use over 400MB just for my developer tools which I have to self-compile due to openlab having old versions of everything).

My log file and my shelve file keep growing (basically 1:1) so I wanted to at least cut the shelve object from growing. The logging of course is out of scope since stdout can be directed anywhere...

This patch allows the user to configure his/her own shelve object. In my case I am using one that I wrote which is backed by postgres: https://gist.github.com/kfatehi/90e27415e15eaeb19f7b
